### PR TITLE
vagrantのマシン名を変更

### DIFF
--- a/p1/Vagrantfile
+++ b/p1/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.box = "ubuntu/focal64"
 
-  config.vm.define "server" do |server|
+  config.vm.define "yokawadaS" do |server|
     server.vm.hostname = "yokawadaS"
     server.vm.provider "virtualbox" do |v|
       v.name = "iot-server-p1"
@@ -19,8 +19,8 @@ Vagrant.configure("2") do |config|
     SHELL
   end
 
-  config.vm.define "agent" do |agent|
-    agent.vm.hostname = "yokawadaSW"
+  config.vm.define "ynakamotSW" do |agent|
+    agent.vm.hostname = "ynakamotSW"
     agent.vm.provider "virtualbox" do |v|
       v.name = "iot-agent-p1"
     end

--- a/p1/memo.md
+++ b/p1/memo.md
@@ -1,8 +1,8 @@
 ## 遊び方
 1. PCにvagrantとvirtualboxをインストールする
 2. このディレクトリで`vagrant up`を実行する
-3. 待っていたらvirtualbox上で仮想マシンが2つ（今はserverとagentと命名している）できるはず
-4. それぞれの仮想マシンに`vagrant ssh [machine]`でssh接続できる
+3. 待っていたらvirtualbox上で仮想マシンが2つできるはず
+4. それぞれの仮想マシンに`vagrant ssh [machine]`でssh接続できる(machine名は`config.vm.define "machine_name"`で指定してある)
 5. serverで`sudo kubectl get nodes -o wide`でkubernetesクラスターのノードとして、2つのVMが動作していることが確認できる
 6. `vagrant halt`でVMをシャットダウン、`Vagrant destroy`でVM削除
 


### PR DESCRIPTION
resolve #2 

## 変更点
issueにも書いた通り
subject的にも仮想マシン名はvagrant上での命名と解釈するほうが良さそうなので、
`config.vm.define "server" do |server|`の"server"の部分を指定されたマシン名に変更